### PR TITLE
Update GitterIntroAkkaAkka.md

### DIFF
--- a/GitterIntroAkkaAkka.md
+++ b/GitterIntroAkkaAkka.md
@@ -1,7 +1,7 @@
 # The akka/akka Gitter Channel
 
-This channel is available for all Akka enthusiasts—newbies as well as gurus—for the exchange of knowledge and the coordination of efforts around Akka; it is a community effort and resource and not backed by Typesafe. For more structured discussions please refer to [the akka-user mailing list](https://groups.google.com/forum/#!forum/akka-user).
+This channel is available for all Akka enthusiasts—newbies as well as gurus—for the exchange of knowledge and the coordination of efforts around Akka; it is a community effort and resource and not backed by Lightbend. For more structured discussions please refer to [the Akka discussion forum](https://discuss.akka.io).
 
-Instead of a long Code of Conduct we rely upon common sense: be kind and respectful to those who are already here and to those who come after you, harassment of any kind will not be tolerated; in case of trouble contact [akka.official](mailto:akka.official@gmail.com).
+The [Lightbend Community Code of Conduct](https://www.lightbend.com/conduct) applies to all Akka Gitter channels, along with all other Akka community resources.
 
-Please also note that this is not an official Akka support channel, for commercial support please contact [Typesafe](mailto:info@typesafe.com) or visit [Typesafe.com](http://www.typesafe.com/).
+Please also note that this is not an official Akka support channel, for commercial support please contact [Lightbend](mailto:info@lightbend.com) or visit [Lightbend.com](https://www.lightbend.com).


### PR DESCRIPTION
- Link to Discourse instead of the deprecated Google Group
- Link to the Lightbend Community Code of Conduct
- Update Typesafe → Lightbend

Ref: #117 for corresponding akka/dev change