### PR TITLE
Update GitterIntroAkkaDev.md

### DIFF
--- a/GitterIntroAkkaDev.md
+++ b/GitterIntroAkkaDev.md
@@ -1,9 +1,9 @@
 # The akka/dev Gitter Channel
 
-This channel is available for all Akka contributors for the exchange of knowledge and the coordination of efforts around Akka; it is a community effort and resource and not backed by Typesafe. For more structured discussions please refer to [the akka-user mailing list](https://groups.google.com/forum/#!forum/akka-user).
+This channel is available for all Akka contributors for the exchange of knowledge and the coordination of efforts around Akka; it is a community effort and resource and not backed by Lightbend. For more structured discussions please refer to [the Akka discussion forum](https://discuss.akka.io).
 
 This channel is not meant to be used for the discussion of questions or ideas around the usage of Akka, it is reserved for coordinating pull requests etc. Please use the akka/akka channel for general discussion.
 
-Instead of a long Code of Conduct we rely upon common sense: be kind and respectful to those who are already here and to those who come after you, harassment of any kind will not be tolerated; in case of trouble contact [akka.official](mailto:akka.official@gmail.com).
+The [Lightbend Community Code of Conduct](https://www.lightbend.com/conduct) applies to all Akka Gitter channels, along with all other Akka community resources.
 
-Please also note that this is not an official Akka support channel, for commercial support please contact [Typesafe](mailto:info@typesafe.com) or visit [Typesafe.com](http://www.typesafe.com/).
+Please also note that this is not an official Akka support channel, for commercial support please contact [Lightbend](mailto:info@lightbend.com) or visit [Lightbend.com](https://www.lightbend.com).


### PR DESCRIPTION
- Link to Discourse instead of the deprecated Google Group
- Link to the Lightbend Community Code of Conduct
- Update Typesafe → Lightbend

Ref: #116 for corresponding akka/akka change